### PR TITLE
[Client / Server] / #18 / reservation payment, chefInfo review, login 관련 수정

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,6 +17,8 @@ import {
   openLoginErrorModal,
   modalStatus,
 } from './features/user/modal';
+import { chefLogin } from './features/chef/chef';
+import { getReservation } from './features/reservation/reservation';
 import { useSelector, useDispatch } from 'react-redux';
 import { login, userStatus } from './features/user/user';
 
@@ -57,29 +59,36 @@ function App() {
     const socialType = localStorage.getItem('socialType');
 
     try {
-      let userResult = await axios.post(`${url}/user/${socialType}`, {
+      let loginResult = await axios.post(`${url}/user/${socialType}`, {
         authorizationCode: authorizationCode,
       });
-      dispatch(openLoginModal());
-      // setIsLoginModalOpen(true);
-
-      dispatch(
-        login({
-          ...userResult.data.userInfo,
-          accessToken: userResult.data.accessToken,
-        })
-      );
-      localStorage.removeItem('socialType');
+      if (loginResult.data.message === 'ok') {
+        if (loginResult.data.userInfo.chefId) {
+          // 셰프라면
+          dispatch(chefLogin({ chefId: loginResult.data.userInfo.chefId }));
+        }
+        // 예약내역이 있다면
+        if (loginResult.data.reservInfo) {
+          dispatch(
+            getReservation({ reservationData: loginResult.data.reservInfo })
+          );
+        }
+        dispatch(
+          login({
+            ...loginResult.data.userInfo,
+            accessToken: loginResult.data.accessToken,
+          })
+        );
+        dispatch(openLoginModal());
+        localStorage.removeItem('socialType');
+      }
     } catch (err) {
       console.log(err.response);
       if (err.message === 'Network Error') {
         dispatch(openLoginErrorModal());
       } else if ((err.response.data.message = 'You Already Signed up')) {
         dispatch(openLoginErrorModal());
-        // setIsLoginErrorModalOpen(true);
       } else {
-        // setIsServerError(true);
-        // setIsLoginErrorModalOpen(true);
         dispatch(openLoginErrorModal());
       }
     }

--- a/client/src/app/store.js
+++ b/client/src/app/store.js
@@ -28,8 +28,8 @@ const reducers = combineReducers({
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['user', 'chef', 'modal'],
-  blacklist: ['review', 'reservation'],
+  whitelist: ['user', 'chef', 'modal', 'reservation'],
+  blacklist: ['review'],
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers);

--- a/client/src/component/chefInfoReview.js
+++ b/client/src/component/chefInfoReview.js
@@ -109,14 +109,12 @@ function ChefAllReview({ reviewLength, query, setMagnifyPic }) {
                     <UserReview key={idx}>
                       <div className='userProfile'>
                         <div className='userProfileWrap'>
-                          {el.userImg === '' ? (
-                            <img src={basic_profile} alt='유저 사진' />
-                          ) : (
-                            <img src={el.userImg} alt='유저 사진' />
-                          )}
+                          <img
+                            src={el.userImg === '' ? basic_profile : el.userImg}
+                            alt='유저 사진'
+                          />
                         </div>
                         <h2 className='userNickname'>{el.nickname}님</h2>
-                        <span>{el.rating}</span>
                         <ChefStar key={idx}>
                           <div>
                             {ratingStar(el, idx).map((ele, idx) => {
@@ -125,27 +123,31 @@ function ChefAllReview({ reviewLength, query, setMagnifyPic }) {
                           </div>
                         </ChefStar>
                       </div>
-                      <div className='reviewTextWrap'>
-                        <p className='reviewText'>{el.eval}</p>
-                      </div>
-                      <div className='reviewPicture'>
+                      <div
+                        className={
+                          el.rvImg.length === 0 ? 'noPicture' : 'reviewPicture'
+                        }
+                      >
                         {el.rvImg.length === 0 ? (
                           <p>등록한 사진이 없습니다.</p>
                         ) : (
                           <div className='reviewPictureFrame'>
                             {el.rvImg.split(',').map((ele, idx) => {
                               return (
-                                <div
+                                <img
                                   key={idx}
+                                  src={ele}
                                   className='reviewPictureItem'
                                   onClick={() => showPicture(ele)}
-                                >
-                                  <img src={ele} alt='코스 사진' />
-                                </div>
+                                  alt='코스 사진'
+                                />
                               );
                             })}
                           </div>
                         )}
+                      </div>
+                      <div className='reviewTextWrap'>
+                        <p className='reviewText'>{el.eval}</p>
                       </div>
                     </UserReview>
                   );

--- a/client/src/component/login.js
+++ b/client/src/component/login.js
@@ -9,6 +9,7 @@ import {
   openServerErrorModal,
   openLoginModal,
 } from '../features/user/modal';
+import { getReservation } from '../features/reservation/reservation';
 import { login, userStatus } from '../features/user/user';
 import { LoginFormWrap } from '../styled/styledLogin';
 import { useForm } from 'react-hook-form';
@@ -51,11 +52,12 @@ function Login() {
           // 셰프라면
           dispatch(chefLogin({ chefId: loginResult.data.userInfo.chefId }));
         }
-        delete loginResult.data.userInfo.chefId; // 바로 지우기
-        // console.log({
-        //   ...loginResult.data.userInfo,
-        //   accessToken: loginResult.data.accessToken,
-        // });
+        // 예약내역이 있다면
+        if (loginResult.data.reservInfo) {
+          dispatch(
+            getReservation({ reservationData: loginResult.data.reservInfo })
+          );
+        }
         dispatch(
           login({
             ...loginResult.data.userInfo,

--- a/client/src/component/reservationDate.js
+++ b/client/src/component/reservationDate.js
@@ -5,12 +5,13 @@ import '../styled/customCalander.css';
 import { ReservationWrap, ReservDateAndInfo } from '../styled/styleReservation';
 import subDays from 'date-fns/subDays';
 import { ko } from 'date-fns/esm/locale';
-import { getYear, getMonth, setHours, setMinutes } from 'date-fns';
+import { getYear, getMonth, setHours, setMinutes, addDays } from 'date-fns';
 import { Controller } from 'react-hook-form';
 import { useEffect } from 'react';
 import { reservationStatus } from '../features/reservation/reservation';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
+import format from 'date-fns/format';
 
 function ReservationDate({
   makeReservation,
@@ -19,12 +20,10 @@ function ReservationDate({
   control,
   errors,
   setSearchAddress,
-  searchAddress,
   address,
   addressErr,
   titleInfo,
   reservation,
-  queryChefId,
 }) {
   // console.log(reservation); // ['2021-12-24T07:00:00.000Z']
   const months = [
@@ -48,12 +47,26 @@ function ReservationDate({
       document.getElementsByClassName('react-datepicker__day') || [];
     if (element) element.focus();
   };
-  // const handleCalendarClose = () =>
-  //   document.removeEventListener('touchstart', handleTouchStart, true);
-
   const reservationState = useSelector(reservationStatus);
-
   let dateFormat = 'yyyy년 MMMM dd일, aa h:mm';
+
+  useEffect(() => {
+    // * startDate 재설정 -> startDate가 titleInfo.reservation이나 reservationState에서 벗어날 때 까지 while문에서 date++1 해주기?
+    // const newTitleInfo = titleInfo.reservation.map((el) => {
+    //   return format(el, 'yyyy-MM-dd');
+    // }); // ['2021-12-19']
+    // const tempReservationState = reservationState.data.map((el) => {
+    //   let utc =
+    //     new Date(el.rsDate).getTime() +
+    //     new Date(el.rsDate).getTimezoneOffset() * 60 * 1000;
+    //   let time_diff = 9 * 60 * 60 * 1000;
+    //   return new Date(utc + time_diff);
+    // });
+    // const newReservationState = tempReservationState.map((el) => {
+    //   return format(el, 'yyyy-MM-dd');
+    // }); // ['2021-12-19', '2021-12-15'];
+  }, []);
+
   return (
     <>
       <ReservationWrap className={makeReservation === 1 ? null : 'none'}>
@@ -71,6 +84,7 @@ function ReservationDate({
                   name='reservDateAndTime'
                   format={dateFormat}
                   defaultValue={null}
+                  rules={{ required: '날짜를 선택해 주세요.' }}
                   render={({ field }) => (
                     <DatePicker
                       withPortal
@@ -92,9 +106,9 @@ function ReservationDate({
                         setHours(setMinutes(new Date(), 0), 19),
                       ]}
                       excludeDates={[
-                        // new Date(),
-                        // subDays(new Date(), -1),
-                        ...reservation.map((el) => new Date(el)),
+                        new Date(),
+                        addDays(new Date(), 1),
+                        ...titleInfo.reservation.map((el) => new Date(el)),
                         ...reservationState.data.map(
                           (el) => new Date(el.rsDate)
                         ),
@@ -145,6 +159,11 @@ function ReservationDate({
                   )}
                 ></Controller>
               </div>
+              {errors.reservDateAndTime && (
+                <span className='reservAlert'>
+                  {errors.reservDateAndTime.message}
+                </span>
+              )}
             </div>
 
             <div className='reservInputWrap'>

--- a/client/src/component/reservationDate.js
+++ b/client/src/component/reservationDate.js
@@ -70,200 +70,208 @@ function ReservationDate({
   return (
     <>
       <ReservationWrap className={makeReservation === 1 ? null : 'none'}>
-        <div className='arrow' onClick={() => setMakeReservation(0)}>
-          &lt;
-        </div>
-        <div className='reservScheduleAndInfo'>
-          <ReservDateAndInfo>
-            <h2>1. 일정 및 개인정보 작성</h2>
-            <div className='reservInputWrap'>
-              <div className='reservInput'>
-                <label htmlFor='reservDateAndTime'>예약 날짜와 시간</label>
-                <Controller
-                  control={control}
-                  name='reservDateAndTime'
-                  format={dateFormat}
-                  defaultValue={null}
-                  rules={{ required: '날짜를 선택해 주세요.' }}
-                  render={({ field }) => (
-                    <DatePicker
-                      withPortal
-                      placeholderText='날짜를 선택해주세요.'
-                      locale={ko}
-                      timeIntervals={60}
-                      selected={field.value}
-                      onChange={(e) => field.onChange(e)}
-                      minDate={new Date()}
-                      onCalendarOpen={handleCalendarOpen}
-                      includeTimes={[
-                        setHours(setMinutes(new Date(), 0), 12),
-                        setHours(setMinutes(new Date(), 0), 13),
-                        setHours(setMinutes(new Date(), 0), 14),
-                        setHours(setMinutes(new Date(), 0), 15),
-                        setHours(setMinutes(new Date(), 0), 16),
-                        setHours(setMinutes(new Date(), 0), 17),
-                        setHours(setMinutes(new Date(), 0), 18),
-                        setHours(setMinutes(new Date(), 0), 19),
-                      ]}
-                      excludeDates={[
-                        new Date(),
-                        addDays(new Date(), 1),
-                        ...titleInfo.reservation.map((el) => new Date(el)),
-                        ...reservationState.data.map(
-                          (el) => new Date(el.rsDate)
-                        ),
-                      ]}
-                      dateFormat={dateFormat}
-                      showTimeSelect
-                      renderCustomHeader={({
-                        date,
-                        prevMonthButtonDisabled,
-                        nextMonthButtonDisabled,
-                        decreaseMonth,
-                        increaseMonth,
-                      }) => (
-                        <div
-                          style={{
-                            margin: 10,
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            fontSize: 20,
-                          }}
-                        >
+        <div
+          className={
+            makeReservation === 1
+              ? 'reservationWrapper'
+              : 'reservationWrapper none'
+          }
+        >
+          <div className='arrow' onClick={() => setMakeReservation(0)}>
+            &lt;
+          </div>
+          <div className='reservScheduleAndInfo'>
+            <ReservDateAndInfo>
+              <h2>1. 일정 및 개인정보 작성</h2>
+              <div className='reservInputWrap'>
+                <div className='reservInput'>
+                  <label htmlFor='reservDateAndTime'>예약 날짜와 시간</label>
+                  <Controller
+                    control={control}
+                    name='reservDateAndTime'
+                    format={dateFormat}
+                    defaultValue={null}
+                    rules={{ required: '날짜를 선택해 주세요.' }}
+                    render={({ field }) => (
+                      <DatePicker
+                        withPortal
+                        placeholderText='날짜를 선택해주세요.'
+                        locale={ko}
+                        timeIntervals={60}
+                        selected={field.value}
+                        onChange={(e) => field.onChange(e)}
+                        minDate={new Date()}
+                        onCalendarOpen={handleCalendarOpen}
+                        includeTimes={[
+                          setHours(setMinutes(new Date(), 0), 12),
+                          setHours(setMinutes(new Date(), 0), 13),
+                          setHours(setMinutes(new Date(), 0), 14),
+                          setHours(setMinutes(new Date(), 0), 15),
+                          setHours(setMinutes(new Date(), 0), 16),
+                          setHours(setMinutes(new Date(), 0), 17),
+                          setHours(setMinutes(new Date(), 0), 18),
+                          setHours(setMinutes(new Date(), 0), 19),
+                        ]}
+                        excludeDates={[
+                          new Date(),
+                          addDays(new Date(), 1),
+                          ...titleInfo.reservation.map((el) => new Date(el)),
+                          ...reservationState.data.map(
+                            (el) => new Date(el.rsDate)
+                          ),
+                        ]}
+                        dateFormat={dateFormat}
+                        showTimeSelect
+                        renderCustomHeader={({
+                          date,
+                          prevMonthButtonDisabled,
+                          nextMonthButtonDisabled,
+                          decreaseMonth,
+                          increaseMonth,
+                        }) => (
                           <div
-                            className='btn_month btn_month-prev'
-                            onClick={decreaseMonth}
-                            disabled={prevMonthButtonDisabled}
                             style={{
-                              cursor: 'pointer',
+                              margin: 10,
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              fontSize: 20,
                             }}
                           >
-                            &lt;
+                            <div
+                              className='btn_month btn_month-prev'
+                              onClick={decreaseMonth}
+                              disabled={prevMonthButtonDisabled}
+                              style={{
+                                cursor: 'pointer',
+                              }}
+                            >
+                              &lt;
+                            </div>
+                            <div className='month-day'>
+                              {getYear(date)}.{months[getMonth(date)]}
+                            </div>
+                            <div
+                              className='btn_month btn_month-next'
+                              onClick={increaseMonth}
+                              disabled={nextMonthButtonDisabled}
+                              style={{
+                                cursor: 'pointer',
+                              }}
+                            >
+                              &gt;
+                            </div>
                           </div>
-                          <div className='month-day'>
-                            {getYear(date)}.{months[getMonth(date)]}
-                          </div>
-                          <div
-                            className='btn_month btn_month-next'
-                            onClick={increaseMonth}
-                            disabled={nextMonthButtonDisabled}
-                            style={{
-                              cursor: 'pointer',
-                            }}
-                          >
-                            &gt;
-                          </div>
-                        </div>
-                      )}
-                    />
-                  )}
-                ></Controller>
+                        )}
+                      />
+                    )}
+                  ></Controller>
+                </div>
+                {errors.reservDateAndTime && (
+                  <span className='reservAlert'>
+                    {errors.reservDateAndTime.message}
+                  </span>
+                )}
               </div>
-              {errors.reservDateAndTime && (
-                <span className='reservAlert'>
-                  {errors.reservDateAndTime.message}
-                </span>
-              )}
-            </div>
 
-            <div className='reservInputWrap'>
-              <div className='reservInput findAddress'>
-                <label htmlFor='reservMainAddress'>주소</label>
-                <input
-                  type='text'
-                  name='reservMainAddress'
-                  placeholder='주소를 입력해주세요.'
-                  defaultValue={address}
-                  onClick={() => setSearchAddress(true)}
-                  id='reservMainAddress'
-                />
+              <div className='reservInputWrap'>
+                <div className='reservInput findAddress'>
+                  <label htmlFor='reservMainAddress'>주소</label>
+                  <input
+                    type='text'
+                    name='reservMainAddress'
+                    placeholder='주소를 입력해주세요.'
+                    defaultValue={address}
+                    onClick={() => setSearchAddress(true)}
+                    id='reservMainAddress'
+                  />
+                </div>
+                {!addressErr ? (
+                  <span className='reservAlert'>주소 입력이 필요합니다.</span>
+                ) : null}
               </div>
-              {!addressErr ? (
-                <span className='reservAlert'>주소 입력이 필요합니다.</span>
-              ) : null}
-            </div>
 
-            <div className='reservInputWrap'>
-              <div className='reservInput'>
-                <label htmlFor='reservSubAddress'>세부 주소</label>
-                <input
-                  type='text'
-                  name='reservSubAddress'
-                  placeholder='세부 주소'
-                  {...register('reservSubAddress', {
-                    required: '세부 주소 입력이 필요합니다.',
-                  })}
-                />
+              <div className='reservInputWrap'>
+                <div className='reservInput'>
+                  <label htmlFor='reservSubAddress'>세부 주소</label>
+                  <input
+                    type='text'
+                    name='reservSubAddress'
+                    placeholder='세부 주소'
+                    {...register('reservSubAddress', {
+                      required: '세부 주소 입력이 필요합니다.',
+                    })}
+                  />
+                </div>
+                {errors.reservSubAddress && (
+                  <span className='reservAlert'>
+                    {errors.reservSubAddress.message}
+                  </span>
+                )}
               </div>
-              {errors.reservSubAddress && (
-                <span className='reservAlert'>
-                  {errors.reservSubAddress.message}
-                </span>
-              )}
-            </div>
 
-            <div className='reservInputWrap'>
-              <div className='reservInput'>
-                <label htmlFor='reservPeople'>인원</label>
-                <Controller
-                  control={control}
-                  name='reservPeople'
-                  render={({ field }) => (
-                    <select
-                      defaultValue={titleInfo.course.peopleMin}
-                      onChange={(e) => field.onChange(e)}
-                    >
-                      {[
-                        titleInfo.course.peopleMin,
-                        titleInfo.course.peopleMax,
-                      ].map((el, idx) => {
-                        return (
-                          <option value={el} key={idx}>
-                            {el}명
-                          </option>
-                        );
-                      })}
-                    </select>
-                  )}
-                />
+              <div className='reservInputWrap'>
+                <div className='reservInput'>
+                  <label htmlFor='reservPeople'>인원</label>
+                  <Controller
+                    control={control}
+                    name='reservPeople'
+                    render={({ field }) => (
+                      <select
+                        defaultValue={titleInfo.course.peopleMin}
+                        onChange={(e) => field.onChange(e)}
+                      >
+                        {[
+                          titleInfo.course.peopleMin,
+                          titleInfo.course.peopleMax,
+                        ].map((el, idx) => {
+                          return (
+                            <option value={el} key={idx}>
+                              {el}명
+                            </option>
+                          );
+                        })}
+                      </select>
+                    )}
+                  />
+                </div>
+                {errors.reservPeople && (
+                  <span className='reservAlert'>
+                    {errors.reservPeople.message}
+                  </span>
+                )}
               </div>
-              {errors.reservPeople && (
-                <span className='reservAlert'>
-                  {errors.reservPeople.message}
-                </span>
-              )}
-            </div>
 
-            <div className='reservInputWrap'>
-              <div className='reservInput'>
-                <label htmlFor='reservMobile'>핸드폰 번호</label>
-                <input
-                  type='text'
-                  name='reservMobile'
-                  placeholder='핸드폰 번호 (ex. 010-1234-5678)'
-                  {...register('reservMobile', {
-                    required: '핸드폰 번호 입력이 필요합니다.',
-                    pattern: {
-                      value: /^[0-9]+$/,
-                      message: '숫자로만 입력해주세요.',
-                    },
-                    pattern: {
-                      value: /^[0-9]{2,3}-[0-9]{3,4}-[0-9]{4}/,
-                      message: '양식에 맞지 않는 전화번호 입니다.',
-                    },
-                  })}
-                />
+              <div className='reservInputWrap'>
+                <div className='reservInput'>
+                  <label htmlFor='reservMobile'>핸드폰 번호</label>
+                  <input
+                    type='text'
+                    name='reservMobile'
+                    placeholder='핸드폰 번호 (ex. 010-1234-5678)'
+                    {...register('reservMobile', {
+                      required: '핸드폰 번호 입력이 필요합니다.',
+                      pattern: {
+                        value: /^[0-9]+$/,
+                        message: '숫자로만 입력해주세요.',
+                      },
+                      pattern: {
+                        value: /^[0-9]{2,3}-[0-9]{3,4}-[0-9]{4}/,
+                        message: '양식에 맞지 않는 전화번호 입니다.',
+                      },
+                    })}
+                  />
+                </div>
+                {errors.reservMobile && (
+                  <span className='reservAlert'>
+                    {errors.reservMobile.message}
+                  </span>
+                )}
               </div>
-              {errors.reservMobile && (
-                <span className='reservAlert'>
-                  {errors.reservMobile.message}
-                </span>
-              )}
-            </div>
-          </ReservDateAndInfo>
-        </div>
-        <div className='arrow' onClick={() => setMakeReservation(2)}>
-          &gt;
+            </ReservDateAndInfo>
+          </div>
+          <div className='arrow' onClick={() => setMakeReservation(2)}>
+            &gt;
+          </div>
         </div>
       </ReservationWrap>
     </>

--- a/client/src/component/reservationDate.js
+++ b/client/src/component/reservationDate.js
@@ -92,8 +92,8 @@ function ReservationDate({
                         setHours(setMinutes(new Date(), 0), 19),
                       ]}
                       excludeDates={[
-                        new Date(),
-                        subDays(new Date(), -1),
+                        // new Date(),
+                        // subDays(new Date(), -1),
                         ...reservation.map((el) => new Date(el)),
                         ...reservationState.data.map(
                           (el) => new Date(el.rsDate)

--- a/client/src/component/reservationInfo.js
+++ b/client/src/component/reservationInfo.js
@@ -9,72 +9,82 @@ function ReservationInfo({
 }) {
   return (
     <ReservationWrap className={makeReservation === 2 ? null : 'none'}>
-      <div className='arrow' onClick={() => setMakeReservation(1)}>
-        &lt;
-      </div>
-      <div className='reservScheduleAndInfo'>
-        <ReservDateAndInfo id='reservInfo'>
-          <h2>2. 세부 정보 작성</h2>
-          <div className='reservInputWrap'>
-            <div className='reservInput'>
-              <label htmlFor='reservFire'>화구 갯수</label>
-              <select
-                name='reservFire'
-                selected='1개'
-                {...register('reservFire', {
-                  validate: (value) =>
-                    value === '1' ? '화구는 최소 2개 이상이여야 합니다.' : null,
-                })}
-              >
-                <option value='1'>1개</option>
-                <option value='2'>2개</option>
-                <option value='3'>3개</option>
-                <option value='4'>4개</option>
-                <option value='5'>4개 이상</option>
-              </select>
-            </div>
-            {errors.reservFire && (
-              <span className='reservAlert'>{errors.reservFire.message}</span>
-            )}
-          </div>
-          <div className='reservInputWrap'>
-            <div className='reservInput'>
-              <label htmlFor='reservOven'>오븐 여부</label>
-              <select name='reservOven' {...register('reservOven')}>
-                <option value='true'>예</option>
-                <option value='false'>아니오</option>
-              </select>
-            </div>
-          </div>
-          <div className='reservInputWrap'>
-            <div className='reservInput'>
-              <label htmlFor='reservAllergy'>알러지</label>
-              <input
-                type='text'
-                name='reservAllergy'
-                placeholder='알러지가 있는 재료에 대해 작성해 주세요.'
-                {...register('reservAllergy')}
-              />
-            </div>
-          </div>
-          <div className='reservInputWrap large'>
-            <div className='reservInput large'>
-              <label htmlFor='reservComment'>셰프에게 전달할 코멘트</label>
-              <textarea
-                name='reservComment'
-                placeholder='셰프에게 전달할 코멘트'
-                {...register('reservComment')}
-              />
-            </div>
-          </div>
-          {Object.keys(errors).length > 0 || !addressErr ? (
+      <div
+        className={
+          makeReservation === 2
+            ? 'reservationWrapper'
+            : 'reservationWrapper none'
+        }
+      >
+        <div className='arrow' onClick={() => setMakeReservation(1)}>
+          &lt;
+        </div>
+        <div className='reservScheduleAndInfo'>
+          <ReservDateAndInfo id='reservInfo'>
+            <h2>2. 세부 정보 작성</h2>
             <div className='reservInputWrap'>
-              <span className='reservAlert'>작성 내용을 확인해주세요.</span>
+              <div className='reservInput'>
+                <label htmlFor='reservFire'>화구 갯수</label>
+                <select
+                  name='reservFire'
+                  selected='1개'
+                  {...register('reservFire', {
+                    validate: (value) =>
+                      value === '1'
+                        ? '화구는 최소 2개 이상이여야 합니다.'
+                        : null,
+                  })}
+                >
+                  <option value='1'>1개</option>
+                  <option value='2'>2개</option>
+                  <option value='3'>3개</option>
+                  <option value='4'>4개</option>
+                  <option value='5'>4개 이상</option>
+                </select>
+              </div>
+              {errors.reservFire && (
+                <span className='reservAlert'>{errors.reservFire.message}</span>
+              )}
             </div>
-          ) : null}
-        </ReservDateAndInfo>
+            <div className='reservInputWrap'>
+              <div className='reservInput'>
+                <label htmlFor='reservOven'>오븐 여부</label>
+                <select name='reservOven' {...register('reservOven')}>
+                  <option value='true'>예</option>
+                  <option value='false'>아니오</option>
+                </select>
+              </div>
+            </div>
+            <div className='reservInputWrap'>
+              <div className='reservInput'>
+                <label htmlFor='reservAllergy'>알러지</label>
+                <input
+                  type='text'
+                  name='reservAllergy'
+                  placeholder='알러지가 있는 재료에 대해 작성해 주세요.'
+                  {...register('reservAllergy')}
+                />
+              </div>
+            </div>
+            <div className='reservInputWrap large'>
+              <div className='reservInput large'>
+                <label htmlFor='reservComment'>셰프에게 전달할 코멘트</label>
+                <textarea
+                  name='reservComment'
+                  placeholder='셰프에게 전달할 코멘트'
+                  {...register('reservComment')}
+                />
+              </div>
+            </div>
+            {Object.keys(errors).length > 0 || !addressErr ? (
+              <div className='reservInputWrap'>
+                <span className='reservAlert'>작성 내용을 확인해주세요.</span>
+              </div>
+            ) : null}
+          </ReservDateAndInfo>
+        </div>
+        <button type='submit'>&gt;</button>
       </div>
-      <button type='submit'>&gt;</button>
     </ReservationWrap>
   );
 }

--- a/client/src/component/reservationNotice.js
+++ b/client/src/component/reservationNotice.js
@@ -3,24 +3,26 @@ import { ReservationWrap, ReservNotice } from '../styled/styleReservation';
 function ReservationNotice({ titleInfo, setMakeReservation }) {
   return (
     <ReservationWrap>
-      <button>&lt;</button>
-      <ReservNotice>
-        <div id='reservationNotice'>
-          <h3>
-            {titleInfo.chefName || ''} 셰프 님의{' '}
-            {titleInfo.course.courseName || ''}코스에 대한 예약입니다.
-          </h3>
-          <p>코스는 1시간 ~ 2시간 내외로 진행 됩니다.</p>
-          <p>예약 시간 1시간 전에 셰프님이 도착하여 준비 할 예정입니다.</p>
-          <p>예약은 7일 전까지 위약금 없이 취소 가능합니다.</p>
-          <p>예약은 7일 전까지 위약금 없이 취소 가능합니다.</p>
-          <p>예약은 7일 전까지 위약금 없이 취소 가능합니다.</p>
-          <p>
-            불편하신 사항이나 문제가 있으신 경우엔 고객 센터로 문의 바랍니다.
-          </p>
-        </div>
-      </ReservNotice>
-      <button onClick={() => setMakeReservation(1)}>&gt;</button>
+      <div className='reservationWrapper'>
+        <button>&lt;</button>
+        <ReservNotice>
+          <div id='reservationNotice'>
+            <h3>
+              {titleInfo.chefName || ''} 셰프 님의{' '}
+              {titleInfo.course.courseName || ''}코스에 대한 예약입니다.
+            </h3>
+            <p>코스는 1시간 ~ 2시간 내외로 진행 됩니다.</p>
+            <p>예약 시간 1시간 전에 셰프님이 도착하여 준비 할 예정입니다.</p>
+            <p>예약은 7일 전까지 위약금 없이 취소 가능합니다.</p>
+            <p>예약은 7일 전까지 위약금 없이 취소 가능합니다.</p>
+            <p>예약은 7일 전까지 위약금 없이 취소 가능합니다.</p>
+            <p>
+              불편하신 사항이나 문제가 있으신 경우엔 고객 센터로 문의 바랍니다.
+            </p>
+          </div>
+        </ReservNotice>
+        <button onClick={() => setMakeReservation(1)}>&gt;</button>
+      </div>
     </ReservationWrap>
   );
 }

--- a/client/src/component/reservationPayment.js
+++ b/client/src/component/reservationPayment.js
@@ -21,8 +21,6 @@ function ReservationPayment({
   const dispatch = useDispatch();
   const reservationData = {
     rsDate: newData.reservDateAndTime,
-    // rsDate 자체는 date객체
-    // format(newData.reservDateAndTime, 'yyyy-MM-dd HH:mm:ss'),
     rsTime: `${getHours(newData.reservDateAndTime)}:${format(
       newData.reservDateAndTime,
       'mm'
@@ -38,7 +36,7 @@ function ReservationPayment({
     rsChefId: Number(queryChefId),
     allergy: newData.reservAllergy,
   };
-
+  console.log('reservationData: ', reservationData);
   const iamportPayment = () => {
     // * 2-1. 결제 준비 (가맹점 식별코드 사용해 IMP 객체 초기화)
     const IMP = window.IMP;
@@ -74,16 +72,11 @@ function ReservationPayment({
         // * axios로 서버에 정보 보내서 결제정보 저장
         const webUrl = 'https://server.todayschef.click';
         let postResult = await axios.post(
-          `${webUrl}/reservation/payments`,
-          // `http://localhost:4000/reservation/payments`,
+          // `${webUrl}/reservation/payments`,
+          `http://localhost:4000/reservation/payments`,
           {
             data: {
-              reservationData: {
-                ...reservationData,
-                rsDate: new Date(
-                  format(newData.reservDateAndTime, 'yyyy-MM-dd HH:mm:ss')
-                ),
-              },
+              reservationData,
               imp_uid,
               merchant_uid,
             },
@@ -96,7 +89,6 @@ function ReservationPayment({
             },
           }
         );
-        console.log('aaa', postResult);
         if (postResult.data.status === 'success') {
           // * 결제 정보 저장 후 다음페이지로
           setMakeReservation(4); // 다음페이지로 넘겨주기

--- a/client/src/features/reservation/reservation.js
+++ b/client/src/features/reservation/reservation.js
@@ -14,9 +14,13 @@ export const reservationSlice = createSlice({
     getReservation: (state, action) => {
       state.data = [...action.payload.reservationData];
     },
+    madeReservation: (state, action) => {
+      state.data = [...state.data, action.payload.newData];
+    },
   },
 });
 
-export const { deleteReservation, getReservation } = reservationSlice.actions;
+export const { deleteReservation, getReservation, madeReservation } =
+  reservationSlice.actions;
 export const reservationStatus = (state) => state.reservation;
 export default reservationSlice.reducer;

--- a/client/src/pages/reservation.js
+++ b/client/src/pages/reservation.js
@@ -23,7 +23,7 @@ import {
 } from '../features/user/modal';
 import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from 'react-hook-form';
-import { setHours, setMinutes } from 'date-fns';
+import { addDays, setHours, setMinutes } from 'date-fns';
 import { reservationStatus } from '../features/reservation/reservation';
 
 require('dotenv').config();
@@ -31,14 +31,11 @@ axios.defaults.withCredentials = true;
 
 function Reservation() {
   const url = process.env.REACT_APP_API_URL || `http://localhost:4000`;
-  let today = new Date(); //오늘
   const dispatch = useDispatch();
   const userState = useSelector(userStatus);
   const modalState = useSelector(modalStatus);
-  const reservationState = useSelector(reservationStatus);
   const [newData, setNewData] = useState({});
   const [makeReservation, setMakeReservation] = useState(0);
-  const [startDate, setStartDate] = useState(new Date());
   const {
     register,
     watch,
@@ -48,7 +45,7 @@ function Reservation() {
   } = useForm({
     mode: 'onChange',
     defaultValues: {
-      reservDateAndTime: setHours(setMinutes(new Date(startDate), 0), 13),
+      reservDateAndTime: '',
       reservSubAddress: '',
       reservPeople: 2,
       reservMobile: '',
@@ -118,9 +115,14 @@ function Reservation() {
           setTitleInfo({
             chefName: data.data.data.chefName,
             course: data.data.data.course,
-            reservation: data.data.data.rsDate,
+            reservation: data.data.data.rsDate.map((el) => {
+              let utc =
+                new Date(el).getTime() +
+                new Date(el).getTimezoneOffset() * 60 * 1000;
+              let time_diff = 9 * 60 * 60 * 1000;
+              return new Date(utc + time_diff); // 한국 시간차에 맞춤
+            }),
           });
-          // * 시작일 잡아주기
         })
         .catch((err) => {
           console.log(err);
@@ -132,8 +134,7 @@ function Reservation() {
         });
     }
   }, []);
-  console.log('titleInfo.reservation: ', titleInfo.reservation);
-  console.log('reservationState: ', reservationState);
+
   return (
     <>
       {modalState.failModalOpen ? <OneSentenceModal /> : null}

--- a/client/src/pages/reservation.js
+++ b/client/src/pages/reservation.js
@@ -24,6 +24,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { useForm } from 'react-hook-form';
 import { setHours, setMinutes } from 'date-fns';
+import { reservationStatus } from '../features/reservation/reservation';
 
 require('dotenv').config();
 axios.defaults.withCredentials = true;
@@ -34,8 +35,10 @@ function Reservation() {
   const dispatch = useDispatch();
   const userState = useSelector(userStatus);
   const modalState = useSelector(modalStatus);
+  const reservationState = useSelector(reservationStatus);
   const [newData, setNewData] = useState({});
   const [makeReservation, setMakeReservation] = useState(0);
+  const [startDate, setStartDate] = useState(new Date());
   const {
     register,
     watch,
@@ -45,10 +48,7 @@ function Reservation() {
   } = useForm({
     mode: 'onChange',
     defaultValues: {
-      reservDateAndTime: setHours(
-        setMinutes(new Date(today.setDate(today.getDate() + 2)), 0),
-        13
-      ),
+      reservDateAndTime: setHours(setMinutes(new Date(startDate), 0), 13),
       reservSubAddress: '',
       reservPeople: 2,
       reservMobile: '',
@@ -77,7 +77,6 @@ function Reservation() {
       setMakeReservation(3); // 다음 페이지로 넘겨주기
     }
   };
-
   const onError = (error) => {
     console.log('onSubmit에서 error: ', error);
   };
@@ -116,12 +115,12 @@ function Reservation() {
           `${url}/reservation?chefId=${queryChefId}&courseId=${queryCourseId}`
         )
         .then((data) => {
-          console.log(data);
           setTitleInfo({
             chefName: data.data.data.chefName,
             course: data.data.data.course,
             reservation: data.data.data.rsDate,
           });
+          // * 시작일 잡아주기
         })
         .catch((err) => {
           console.log(err);
@@ -133,7 +132,8 @@ function Reservation() {
         });
     }
   }, []);
-
+  console.log('titleInfo.reservation: ', titleInfo.reservation);
+  console.log('reservationState: ', reservationState);
   return (
     <>
       {modalState.failModalOpen ? <OneSentenceModal /> : null}

--- a/client/src/pages/reservation.js
+++ b/client/src/pages/reservation.js
@@ -89,7 +89,6 @@ function Reservation() {
   const URLSearch = new URLSearchParams(window.location.search);
   const queryChefId = URLSearch.get('chefId');
   const queryCourseId = URLSearch.get('courseId');
-
   useEffect(() => {
     if (userState.isChef || userState.isAdmin) {
       dispatch(
@@ -196,6 +195,7 @@ function Reservation() {
             <ReservationPayment
               setMakeReservation={setMakeReservation}
               newData={newData}
+              titleInfo={titleInfo}
               queryChefId={queryChefId}
               queryCourseId={queryCourseId}
             />

--- a/client/src/pages/reservationDonePage.js
+++ b/client/src/pages/reservationDonePage.js
@@ -18,22 +18,11 @@ function MobileReservationDonePage() {
   let merchant_uid = URLSearch.get('merchant_uid');
   let imp_success = URLSearch.get('imp_success');
   // console.log('URLSearch.toString(): ', URLSearch.toString());
-
-  console.log('reservationData: ', reservationData);
-  console.log('reservationRsDate: ', reservationRsDate);
-  console.log('typeof reservationRsDate: ', typeof reservationRsDate);
-  console.log(
-    'new Date(reservationData.rsDate): ',
-    new Date(reservationData.rsDate)
-  );
-  console.log(
-    'format(new Date(reservationData.rsDate), "yyyy-MM-dd HH:mm:ss"): ',
-    format(new Date(reservationData.rsDate), 'yyyy-MM-dd HH:mm:ss')
-  );
-  console.log(
-    'new Date(format(new Date(reservationData.rsDate), "yyyy-MM-dd HH:mm:ss")): ',
-    new Date(format(new Date(reservationData.rsDate), 'yyyy-MM-dd HH:mm:ss'))
-  );
+  let utc =
+    new Date(reservationRsDate).getTime() +
+    new Date(reservationRsDate).getTimezoneOffset() * 60 * 1000;
+  let time_diff = 9 * 60 * 60 * 1000;
+  let cur_date_korea = new Date(utc + time_diff);
 
   const url = process.env.REACT_APP_API_URL || `http://localhost:4000`;
   const userState = useSelector(userStatus);
@@ -48,7 +37,7 @@ function MobileReservationDonePage() {
           data: {
             reservationData: {
               ...reservationData,
-              rsDate: new Date(reservationData.rsDate),
+              rsDate: cur_date_korea,
             },
             imp_uid,
             merchant_uid,

--- a/client/src/pages/reservationDonePage.js
+++ b/client/src/pages/reservationDonePage.js
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { useEffect, useState } from 'react';
-import { updateAccessToken, userStatus } from '../features/user/user';
-import { useSelector } from 'react-redux';
-import { format } from 'date-fns';
+import { userStatus } from '../features/user/user';
+import { madeReservation } from '../features/reservation/reservation';
+import { openFailModal } from '../features/user/modal';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   MobileReservation,
   ReservationWrap,
@@ -10,8 +11,11 @@ import {
 } from '../styled/styleReservation';
 
 function MobileReservationDonePage() {
-  // * 성공하면 ${url}/mobile/reservationDone?reservationData=${JSON.stringify(reservationData)&imp_uid=~~~&merchant_uid=~~~&imp_success=true}
+  // * 성공하면 ${url}/mobile/reservationDone?chefName=~~~&courseName=~~~&reservationData=${JSON.stringify(reservationData)&imp_uid=~~~&merchant_uid=~~~&imp_success=true}
   const URLSearch = new URLSearchParams(window.location.search);
+  const dispatch = useDispatch();
+  let chefName = decodeURIComponent(URLSearch.get('chefName'));
+  let courseName = decodeURIComponent(URLSearch.get('courseName'));
   let reservationData = JSON.parse(URLSearch.get('reservationData'));
   let reservationRsDate = reservationData.rsDate;
   let imp_uid = URLSearch.get('imp_uid');
@@ -54,11 +58,26 @@ function MobileReservationDonePage() {
         console.log(data);
         if (data.data.status === 'success') {
           // * 결제 정보 저장 후 다음페이지로
+          dispatch(
+            madeReservation({
+              newData: {
+                ...reservationData,
+                rsDate: String(reservationData.rsDate),
+                chefName: chefName,
+                courseName: courseName,
+              },
+            })
+          ); // redux reservation 업뎃시켜주기
           setSaveStatus(true); // 저장 완료 상태
         }
       })
       .catch((error) => {
         console.log(error);
+        dispatch(
+          openFailModal({
+            message: '결제가 중단되었습니다.',
+          })
+        );
       });
   }, []);
 

--- a/client/src/styled/styleChefInfo.js
+++ b/client/src/styled/styleChefInfo.js
@@ -337,22 +337,15 @@ export const ReviewPagenation = styled.div`
 
 export const UserReview = styled.div`
   width: 100%;
+  height: auto;
   display: grid;
-  grid-template-rows: 80px 100px 80px;
+  grid-template-rows: 80px 140px 1fr;
   row-gap: 10px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-
-  @media screen and (max-width: 767px) {
-    width: 100%;
-    height: 280px;
-  }
-  @media screen and (max-width: 420px) {
-    height: 300px;
-    grid-template-rows: 80px 120px 80px;
-  }
+  background-color: rgba(219, 184, 154, 0.4);
   .userProfile {
     display: grid;
-    grid-template-columns: 80px 4fr 1fr 5fr;
+    grid-template-columns: 80px 1fr 1fr;
     .userProfileWrap {
       img {
         width: 60px;
@@ -368,44 +361,38 @@ export const UserReview = styled.div`
     }
   }
   .reviewTextWrap {
+    min-height: 60px;
     display: grid;
     place-items: center;
     text-align: left;
+    padding: 5px;
+    background-color: #dbb89a;
     > p {
-      width: 95%;
-      height: 90%;
-      @media screen and (max-width: 767px) {
-        width: 95%;
-        height: 95%;
-      }
-      @media screen and (max-width: 420px) {
-        width: 95%;
-        height: 90%;
-      }
-      @media screen and (max-width: 320px) {
-        width: 100%;
-        height: 100%;
+      line-height: 1.3;
+      &::before {
+        content: ': ';
       }
     }
   }
+  .noPicture {
+    display: grid;
+    place-items: center;
+  }
   .reviewPicture {
     display: grid;
-    place-items: center left;
-
-    background-color: #dbb89a;
+    place-items: center;
     > .reviewPictureFrame {
-      height: 90%;
-      display: grid;
-      margin-left: 10px;
-      grid-template-columns: repeat(2, 1fr);
-      column-gap: 10px;
-      .reviewPictureItem {
-        display: grid;
-        place-items: center;
-        img {
-          width: 60px;
-          height: 60px;
-          cursor: pointer;
+      > img {
+        width: 140px;
+        height: 140px;
+        cursor: pointer;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+        transition: all 0.3s;
+        &:hover {
+          box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
+        }
+        &:nth-child(2) {
+          margin-left: 10px;
         }
       }
     }

--- a/client/src/styled/styleChefInfo.js
+++ b/client/src/styled/styleChefInfo.js
@@ -358,6 +358,7 @@ export const UserReview = styled.div`
         width: 60px;
         height: 60px;
         border-radius: 80px;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
         text-align: center;
       }
     }
@@ -389,11 +390,13 @@ export const UserReview = styled.div`
   }
   .reviewPicture {
     display: grid;
-    place-items: center;
+    place-items: center left;
+
     background-color: #dbb89a;
     > .reviewPictureFrame {
       height: 90%;
       display: grid;
+      margin-left: 10px;
       grid-template-columns: repeat(2, 1fr);
       column-gap: 10px;
       .reviewPictureItem {

--- a/client/src/styled/styleMypage.js
+++ b/client/src/styled/styleMypage.js
@@ -144,19 +144,22 @@ export const MypageReservContent = styled.div`
     column-gap: 10px;
     @media (max-width: 420px) {
       grid-template-columns: none;
-      grid-template-rows: 40px 1fr 70px;
+      grid-template-rows: 30px 1fr 70px;
+      row-gap: 10px;
     }
     #deleteReserve {
       width: 100%;
       height: 100%;
       display: grid;
-      grid-template-rows: repeat(2, 1fr);
+      grid-template-rows: 1fr;
+      grid-auto-rows: 1fr;
       row-gap: 10px;
       place-items: center;
       @media (max-width: 420px) {
         grid-template-rows: none;
         row-gap: 0px;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: 1fr;
+        grid-auto-columns: 1fr;
         column-gap: 10px;
       }
       > button {
@@ -642,10 +645,9 @@ export const MypageEditContent = styled.div`
           }
           > button {
             background-color: #ff6d6d;
-            color: #fff;
-            font-weight: bold;
+            color: #000;
             padding: 8px;
-            font-size: 12px;
+            font-size: 14px;
             border-radius: 5px;
             cursor: pointer;
           }

--- a/client/src/styled/styleReservation.js
+++ b/client/src/styled/styleReservation.js
@@ -63,48 +63,57 @@ export const ReservationWrap = styled.div`
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 50px 1fr 50px;
+  place-items: center;
   background: url(${basic_background}) center;
-  @media screen and (max-width: 420px) {
-    grid-template-columns: 30px 1fr 30px;
-  }
   &.none {
     display: none;
   }
-  &.reservDone,
-  &#reservPayment {
-    grid-template-columns: none;
-    place-items: center;
-  }
-  button {
-    display: block;
-    background-color: transparent;
-    font-size: 45px;
-    cursor: pointer;
-    transition: all 0.2s;
-    @media screen and (max-width: 420px) {
-      font-size: 35px;
-    }
-  }
-  .arrow {
+  .reservationWrapper {
+    width: 800px;
     display: grid;
-    place-items: center;
-    font-size: 45px;
-    cursor: pointer;
-    transition: all 0.2s;
-    @media screen and (max-width: 420px) {
-      font-size: 35px;
+    grid-template-columns: 50px 1fr 50px;
+    @media screen and (max-width: 767px) {
+      width: 100%;
     }
-  }
-  button:hover,
-  .arrow:hover {
-    color: #fff;
-  }
-  > .reservScheduleAndInfo {
-    width: 100%;
-    height: 100%;
-    display: grid;
-    place-items: center;
+    @media screen and (max-width: 420px) {
+      grid-template-columns: 30px 1fr 30px;
+    }
+    &.none {
+      display: none;
+    }
+    &.reservDone,
+    &#reservPayment {
+      grid-template-columns: none;
+      place-items: center;
+    }
+    button {
+      display: block;
+      background-color: transparent;
+      font-size: 45px;
+      cursor: pointer;
+      transition: all 0.2s;
+      @media screen and (max-width: 420px) {
+        font-size: 35px;
+      }
+    }
+    .arrow {
+      display: grid;
+      place-items: center;
+      font-size: 45px;
+      cursor: pointer;
+      transition: all 0.2s;
+      @media screen and (max-width: 420px) {
+        font-size: 35px;
+      }
+    }
+    button:hover,
+    .arrow:hover {
+      color: #fff;
+    }
+    > .reservScheduleAndInfo {
+      width: 100%;
+      height: 100%;
+    }
   }
 `;
 
@@ -196,7 +205,7 @@ export const ReservNotice = styled.div`
 `;
 
 export const ReservDateAndInfo = styled.div`
-  width: 70%;
+  width: 100%;
   height: auto;
   max-width: 700px;
   border-radius: 10px;

--- a/server/controllers/reservation/payments.js
+++ b/server/controllers/reservation/payments.js
@@ -14,7 +14,6 @@ module.exports = {
   post: async (req, res) => {
     try {
       const { imp_uid, merchant_uid } = req.body.data;
-
       const {
         people,
         allergy,
@@ -30,13 +29,7 @@ module.exports = {
         rsCourseId,
         merchent_uid,
       } = req.body.data.reservationData;
-
       const accessVerify = isAuthorized(req);
-
-      // console.log(refreshVerify);
-
-      console.log('req : ', req.body.data);
-      console.log('accssVeri : ', accessVerify);
 
       if (!accessVerify) {
         const refreshVerify = refreshAuthorized(req);
@@ -52,7 +45,7 @@ module.exports = {
             allergy: allergy,
             location: location,
             mobile: mobile,
-            rsDate: rsDate,
+            rsDate: cur_date_korea,
             rsTime: rsTime,
             isOven: isOven,
             burner: burner,
@@ -72,8 +65,6 @@ module.exports = {
             rvReservationId: makeReservation.dataValues.id,
           });
 
-          console.log('첫빠따');
-
           const getToken = await axios({
             url: 'https://api.iamport.kr/users/getToken',
             method: 'post', // POST method
@@ -85,20 +76,12 @@ module.exports = {
           });
           const { access_token } = getToken.data.response; // 인증 토큰
 
-          console.log('req_body', req.body);
-          console.log('getToken : ', getToken.data);
-
-          console.log('imp_uid', req.body.data.imp_uid);
-
           const getPaymentData = await axios({
             url: `https://api.iamport.kr/payments/${imp_uid}`, // imp_uid 전달
             method: 'get', // GET method
             headers: { Authorization: access_token }, // 인증 토큰 Authorization header에 추가
           });
           const paymentData = getPaymentData.data.response; // 조회한 결제 정보
-
-          console.log('getPaymentData : ', getPaymentData);
-          console.log('aaa', paymentData);
 
           await reservation.update(
             {
@@ -135,7 +118,7 @@ module.exports = {
           allergy: allergy,
           location: location,
           mobile: mobile,
-          rsDate: rsDate,
+          rsDate: cur_date_korea,
           rsTime: rsTime,
           isOven: isOven,
           burner: burner,
@@ -155,8 +138,6 @@ module.exports = {
           rvReservationId: makeReservation.dataValues.id,
         });
 
-        console.log('첫빠따');
-
         const getToken = await axios({
           url: 'https://api.iamport.kr/users/getToken',
           method: 'post', // POST method
@@ -168,20 +149,12 @@ module.exports = {
         });
         const { access_token } = getToken.data.response; // 인증 토큰
 
-        console.log('req_body', req.body);
-        console.log('getToken : ', getToken.data);
-
-        console.log('imp_uid', req.body.data.imp_uid);
-
         const getPaymentData = await axios({
           url: `https://api.iamport.kr/payments/${imp_uid}`, // imp_uid 전달
           method: 'get', // GET method
           headers: { Authorization: access_token }, // 인증 토큰 Authorization header에 추가
         });
         const paymentData = getPaymentData.data.response; // 조회한 결제 정보
-
-        console.log('getPaymentData : ', getPaymentData);
-        console.log('aaa', paymentData);
 
         await reservation.update(
           {

--- a/server/controllers/reservation/reservation.js
+++ b/server/controllers/reservation/reservation.js
@@ -73,8 +73,8 @@ module.exports = {
     const refreshVerify = refreshAuthorized(req);
 
     const findReservation = await reservation.findAll({
-      where: { rsCourseId: req.query.courseId },
-    });
+      where: { rsChefId: req.query.chefId },
+    }); // 셰프의 모든 예약을 받아와야 해서 chefId로 검색하는걸로 수정
 
     const filterReservationDate = findReservation.filter(
       (el) => el.rsDate >= new Date()

--- a/server/controllers/reservation/reservation.js
+++ b/server/controllers/reservation/reservation.js
@@ -35,7 +35,7 @@ module.exports = {
         allergy: allergy,
         location: location,
         mobile: mobile,
-        rsDate: rsDate,
+        rsDate: cur_date_korea,
         rsTime: rsTime,
         isOven: isOven,
         burner: burner,

--- a/server/controllers/token/accessToken.js
+++ b/server/controllers/token/accessToken.js
@@ -15,21 +15,15 @@ module.exports = {
     if (!token) {
       return false;
     } else {
-      console.log('token 있어서 들어옴');
       try {
-        console.log('tokenCheck시작');
         const tokenCheck = jwt.verify(token, process.env.ACCESS_SECRET);
         // 이 밑에서부터 console.log찍는거 아무것도 안찍힘
-        console.log('tokenCheck: ', tokenCheck);
         if (!tokenCheck) {
-          console.log('jwt.verify false');
           return false;
         } else {
-          console.log('jwt.verify true');
           return tokenCheck;
         }
       } catch (err) {
-        console.log('jwt.verify false/true는 아닌데 오류 있음');
         return false;
       }
     }

--- a/server/controllers/user/google.js
+++ b/server/controllers/user/google.js
@@ -1,4 +1,4 @@
-const { user, chef } = require('../../models');
+const { user, chef, reservation } = require('../../models');
 const { basicAccessToken } = require('../token/accessToken');
 const {
   basicRefreshToken,
@@ -11,9 +11,7 @@ require('dotenv').config();
 module.exports = {
   post: async (req, res) => {
     const { authorizationCode } = req.body;
-    console.log('authorizationCode', authorizationCode);
     if (!authorizationCode) {
-      console.log('첫쨰');
       res.status(400).json({ message: 'authorizationCode does not exist' });
     }
 
@@ -27,13 +25,10 @@ module.exports = {
       redirect_url
     );
 
-    console.log('googleClient', googleClient);
-
     let code;
     try {
       code = await googleClient.getToken(authorizationCode);
     } catch (error) {
-      console.log('둘쨰');
       console.log(error);
       res.status(400).json({ message: 'authorizationCode does not exist' });
     }
@@ -82,14 +77,25 @@ module.exports = {
         sendRefreshToken(res, refreshToken);
 
         if (!userUsingEmail.dataValues.isChef) {
-          res.status(200).json({ accessToken, userInfo: userUsingEmail });
+          const reservInfo = await reservation.findAll({
+            where: { rsUserId: findUser.dataValues.id },
+          }); // 예약정보
+          res
+            .status(200)
+            .json({
+              message: 'ok',
+              accessToken,
+              reservInfo,
+              userInfo: userUsingEmail,
+            });
         } else {
           const findChef = await chef.findOne({
             where: { chUserId: userUsingEmail.dataValues.id },
           });
-
           userUsingEmail.dataValues.chefId = findChef.dataValues.id;
-          res.status(200).json({ accessToken, userInfo: userUsingEmail });
+          res
+            .status(200)
+            .json({ message: 'ok', accessToken, userInfo: userUsingEmail });
         }
       } else {
         res.status(400).json({ message: 'You Already Signed up' });

--- a/server/controllers/user/login.js
+++ b/server/controllers/user/login.js
@@ -1,4 +1,4 @@
-const { user, chef } = require('../../models');
+const { user, chef, reservation } = require('../../models');
 const { basicAccessToken } = require('../token/accessToken');
 const {
   basicRefreshToken,
@@ -11,7 +11,6 @@ module.exports = {
     const { email, password } = req.body;
     const userInfo = await user.findOne({ where: { email } });
 
-    console.log(userInfo);
     if (!userInfo) {
       res.status(400).json({ message: 'Invalid User' });
     } else {
@@ -25,11 +24,15 @@ module.exports = {
         delete userInfo.dataValues.updatedAt;
         const accessToken = basicAccessToken(userInfo.dataValues);
         const refreshToken = basicRefreshToken(userInfo.dataValues);
-
+        const reservInfo = await reservation.findAll({
+          where: { rsUserId: userInfo.dataValues.id },
+        }); // 예약정보
         sendRefreshToken(res, refreshToken);
 
         if (!userInfo.dataValues.isChef) {
-          res.status(200).json({ accessToken, userInfo, message: 'ok' });
+          res
+            .status(200)
+            .json({ accessToken, userInfo, reservInfo, message: 'ok' });
         } else {
           const findChef = await chef.findOne({
             where: { chUserId: userInfo.dataValues.id },


### PR DESCRIPTION
- 일반 유저 로그인 시 예약 정보 받아오도록 수정
  - 원래 서버에서는 기본적인 유저 정보만 넘겨주고 있었는데, 그렇게 되면 일반 유저가 로그인 하자마자 예약 페이지로 가게 되면 해당 유저의 예약 내역이 없어서 react-date-picker의 `excludeDates`에 추가할 수 없었음
  - 일반 로그인, 구글 / 카카오 소셜 로그인의 경우에 유저의 예약 내역을 찾아 보내는 작업과 성공 메세지 추가함
- reservationDate 날짜 기본값 관련 수정
  - 예약할 때 서버에서 db에 날짜를 넣어주게 되면 db에서는 UTC 기준으로 잡혀서 9시간이 빠진 상태로 변경되곤 했음
  - 서버, 클라이언트 쪽에서 시차를 계산해서 넘겨주게 되어도 db에 입력되는 시간 자체는 시차가 생긴 상태로 들어가게 되서, 차라리 클라이언트에서 사용할 때 시차를 계산해서 보여주는 식으로 바꿈
  - 날짜 기본값을 지정하지 않고 보여줘서 처음엔 placeholder만 보였다가, 시간을 지정해야 온전히 날짜와 시간이 보이는 식으로 수정함
- reservation 페이지 내 컴포넌트 css 수정 (화살표가 조금 더 가까이에 존재하도록)
- reservation 관련 redux, css 수정
  - 결제를 하고 나면 db에는 저장이 되는데, 새로운 예약이 redux에 반영이 안되어 있어서 예약을 할 때 마다 실행될 reducer 만듬
  - 모바일의 경우에는 reservationDone 페이지로 이동 후 서버 저장 작업이 진행되는데, redux 작업을 할땐 courseName, chefName이 필요해 get parameter에 추가해 주었음
    - 다른 get parameter들과는 달리 한글로 전달한 부분이라 `encodeURIComponent`, `decodeURIComponent`를 사용해 한글이 깨지지 않도록 했음. 하지만 배포 환경에서 봐야 해서 아직 확인은 못한 상태임
  - 웹의 경우에는 redux도 업데이트 되는걸 확인 했음
- chefInfo review html, css 구조 변경